### PR TITLE
Bug fix for building 1-4 exclusion list for GROMACS

### DIFF
--- a/fftool
+++ b/fftool
@@ -159,6 +159,7 @@ class atom(object):
         self.x = 0.0
         self.y = 0.0
         self.z = 0.0
+        self.bond_partners = []
 
     def __str__(self):
         if hasattr(self, 'type'):
@@ -862,6 +863,11 @@ class mol(object):
         natom = len(self.atom)
         nbond = len(self.bond)
 
+        # set up bond partners so that we can build 1-4 exclusion list easily
+        for bd in self.bond:
+            self.atom[bd.i].bond_partners.append(bd.j)
+            self.atom[bd.j].bond_partners.append(bd.i)
+
         # identify valence angles
         for i in range(natom):  # find neighbour atoms to each atom i
             nb = 0
@@ -1088,19 +1094,6 @@ class mol(object):
                 toremove.append(di)
                 if names[0] not in dimiss:
                     dimiss.append(names[0])
-        for di in toremove:
-            self.dimpr.remove(di)
-
-        # remove dupplicate impropers differing by i-j or j-i
-        toremove = []
-        for i in range(len(self.dimpr) - 1):
-            for j in range(i + 1, len(self.dimpr)):
-                if self.dimpr[i].i == self.dimpr[j].j and \
-                    self.dimpr[i].j == self.dimpr[j].i or \
-                    self.dimpr[i].i == self.dimpr[j].i and \
-                    self.dimpr[i].j == self.dimpr[j].j:
-                    if self.dimpr[j] not in toremove:
-                        toremove.append(self.dimpr[j])
         for di in toremove:
             self.dimpr.remove(di)
 
@@ -1930,33 +1923,31 @@ class system(object):
                              di.par[0], di.par[1], di.par[2], di.par[3]))
                 f.write('\n')
 
+                # 1-4 exclusion list should be built from bond instead of dihedral
+                pairs12_set = set()
+                pairs13_set = set()
+                pairs14_set = set()
+                for bd in sp.bond:
+                    a2, a3 = bd.i, bd.j
+                    pairs12_set.add(list(sorted([a2, a3])))
+                    for a1 in sp.atom[a2].bond_partners:
+                        if a1 != a3:
+                            pairs13_set.add(list(sorted([a1, a3])))
+                    for a4 in sp.atom[a3].bond_partners:
+                        if a2 != a4:
+                            pairs13_set.add(list(sorted([a2, a4])))
+                    for a1 in sp.atom[a2].bond_partners:
+                        for a4 in sp.atom[a3].bond_partners:
+                            if a1 != a3 and a2 != a4 and a1 != a4:
+                                pairs14_set.add(list(sorted([a1, a4])))
+                # kick out the 1-2 and 1-3 pairs if there are 4- or 5-member rings
+                pairs14 = list(sorted(pairs14_set - pairs12_set.union(pairs13_set)))
+
                 f.write('[ pairs ]\n')
                 f.write(';   ai   aj   func\n')
-                pairs = []
-                for dh in sp.dihed:
-                    inbond = False
-                    inangle = False
-                    dupl = False
-                    for bd in sp.bond: # exclude 1-2 (4-membered rings)
-                        if dh.i == bd.i and dh.l == bd.j or \
-                           dh.i == bd.j and dh.l == bd.i:
-                            inbond = True
-                            break
-                    for an in sp.angle: # exclude 1-3 (5-membered rings)
-                        if dh.i == an.i and dh.l == an.k or \
-                           dh.i == an.k and dh.l == an.i:
-                            inangle = True
-                            break
-                    for p in pairs:     # remove duplicate (6-membered rings)
-                        if dh.i == p[0] and dh.l == p[1] or \
-                           dh.i == p[1] and dh.l == p[0]:
-                            dupl = True
-                            break
-                    if inbond or inangle or dupl:
-                        continue
-                    pairs.append([dh.i, dh.l])
+                for i, j in pairs14:
                     f.write('{0:5d} {1:5d}     {2:2d}\n'\
-                             .format(dh.i + 1, dh.l + 1, 1))
+                             .format(i + 1, j + 1, 1))
                 f.write('\n')
 
             f.write('[ system ]\n')

--- a/fftool
+++ b/fftool
@@ -1786,8 +1786,8 @@ class system(object):
             for sp in self.spec:
                 for im in range(sp.nmol):
                     for at in sp.atom:
-                        f.write("{0:7d} {1:7d} {2:4d} {3:8.4f} "\
-                                 "{4:13.6e} {5:13.6e} {6:13.6e}  "\
+                        f.write("{0:7d} {1:7d} {2:4d} {3:10.6f} "\
+                                 "{4:8.3f} {5:8.3f} {6:8.3f}  "\
                                  "# {7} {8}\n".format(
                                  i + 1, nmol + 1, at.ityp + 1, at.q, 
                                  self.x[i], self.y[i], self.z[i],
@@ -1877,7 +1877,7 @@ class system(object):
                 i = 1
                 for at in sp.atom:
                     f.write('{0:5d}   {1:4s}  {2:5d}  {3:6s}   {4:5s}  {5:4d}'\
-                            '  {6:8.4f}\n'.format(i, at.name, 1,
+                            '  {6:10.6f}\n'.format(i, at.name, 1,
                             sp.name[0:5], at.name, 1, at.q))
                     i += 1
                 f.write('\n')
@@ -1929,19 +1929,19 @@ class system(object):
                 pairs14_set = set()
                 for bd in sp.bond:
                     a2, a3 = bd.i, bd.j
-                    pairs12_set.add(list(sorted([a2, a3])))
+                    pairs12_set.add(tuple(sorted([a2, a3])))
                     for a1 in sp.atom[a2].bond_partners:
                         if a1 != a3:
-                            pairs13_set.add(list(sorted([a1, a3])))
+                            pairs13_set.add(tuple(sorted([a1, a3])))
                     for a4 in sp.atom[a3].bond_partners:
                         if a2 != a4:
-                            pairs13_set.add(list(sorted([a2, a4])))
+                            pairs13_set.add(tuple(sorted([a2, a4])))
                     for a1 in sp.atom[a2].bond_partners:
                         for a4 in sp.atom[a3].bond_partners:
                             if a1 != a3 and a2 != a4 and a1 != a4:
-                                pairs14_set.add(list(sorted([a1, a4])))
+                                pairs14_set.add(tuple(sorted([a1, a4])))
                 # kick out the 1-2 and 1-3 pairs if there are 4- or 5-member rings
-                pairs14 = list(sorted(pairs14_set - pairs12_set.union(pairs13_set)))
+                pairs14 = tuple(sorted(pairs14_set - pairs12_set.union(pairs13_set)))
 
                 f.write('[ pairs ]\n')
                 f.write(';   ai   aj   func\n')

--- a/fftool
+++ b/fftool
@@ -1878,7 +1878,7 @@ class system(object):
                 for at in sp.atom:
                     f.write('{0:5d}   {1:4s}  {2:5d}  {3:6s}   {4:5s}  {5:4d}'\
                             '  {6:10.6f}\n'.format(i, at.name, 1,
-                            sp.name[0:5], at.name, i, at.q))
+                            sp.name[0:5], atomic_symbol(at.name), i, at.q))
                     i += 1
                 f.write('\n')
 
@@ -1970,7 +1970,7 @@ class system(object):
                     for at in sp.atom:
                         f.write('HETATM{0:5d} {1:4s} {2:3s}  {3:4d}    '\
                                 '{4:8.3f}{5:8.3f}{6:8.3f}  1.00  0.00'\
-                                '          {7:2s}\n'.format(i + 1, at.name,
+                                '          {7:2s}\n'.format(i + 1, atomic_symbol(at.name),
                                 sp.name[:3], nmol + 1,
                                 self.x[i], self.y[i], self.z[i],
                                 atomic_symbol(at.name)))
@@ -1987,8 +1987,9 @@ class system(object):
             f.write('nstxout-compressed    = 1000\n\n')
 
             f.write('cutoff-scheme         = Verlet\n')
+            f.write('rlist                 = 1.2\n')
             f.write('pbc                   = xyz\n\n')
-            
+
             f.write('coulombtype           = PME\n')
             f.write('rcoulomb              = 1.2\n')
             f.write('ewald-rtol            = 1.0e-5\n')
@@ -1998,13 +1999,13 @@ class system(object):
 
             f.write('tcoupl                = no; V-rescale\n')
             f.write('tc-grps               = System\n')
-            f.write('tau-t                 = 0.1\n')
+            f.write('tau-t                 = 1.0; 0.1\n')
             f.write('ref-t                 = 300.0\n\n')
 
             f.write('pcoupl                = Berendsen; Parrinello-Rahman\n')
             f.write('pcoupltype            = isotropic\n')
-            f.write('tau-p                 = 1.0; 5.0\n')
-            f.write('ref-p                 = 1.0\n\n')
+            f.write('tau-p                 = 0.5; 5.0\n')
+            f.write('ref-p                 = 1.0\n')
             f.write('compressibility       = 4.5e-5\n')
 
             f.write('gen-vel               = yes\n')

--- a/fftool
+++ b/fftool
@@ -1878,7 +1878,7 @@ class system(object):
                 for at in sp.atom:
                     f.write('{0:5d}   {1:4s}  {2:5d}  {3:6s}   {4:5s}  {5:4d}'\
                             '  {6:10.6f}\n'.format(i, at.name, 1,
-                            sp.name[0:5], at.name, 1, at.q))
+                            sp.name[0:5], at.name, i, at.q))
                     i += 1
                 f.write('\n')
 
@@ -1898,29 +1898,6 @@ class system(object):
                     if bd.pot == 'cons':
                         f.write('{0:5d} {1:5d}     {2:2d}  {3:9.5f}\n'\
                                 .format(bd.i + 1, bd.j + 1, 1, bd.par[0]/10.0))
-                f.write('\n')
-
-                f.write('[ angles ]\n')
-                f.write(';  ai    aj    ak   func    th0        cth\n')
-                for an in sp.angle:
-                    f.write('{0:5d} {1:5d} {2:5d}     {3:2d}  '
-                            '{4:9.3f}  {5:9.3f}\n'\
-                             .format(an.i + 1, an.j + 1, an.k + 1, 1,
-                             an.par[0], an.par[1]))
-                f.write('\n')
-
-                f.write('[ dihedrals ]\n')
-                f.write(';  ai    aj    ak    al   func    coefficients\n')
-                for dh in sp.dihed:
-                    f.write('{0:5d} {1:5d} {2:5d} {3:5d}     {4:2d}  '
-                            '{5:9.5f} {6:9.5f} {7:9.5f} {8:9.5f}\n'\
-                             .format(dh.i + 1, dh.j + 1, dh.k + 1, dh.l + 1, 5,
-                             dh.par[0], dh.par[1], dh.par[2], dh.par[3]))
-                for di in sp.dimpr:
-                    f.write('{0:5d} {1:5d} {2:5d} {3:5d}     {4:2d}  '
-                            '{5:9.5f} {6:9.5f} {7:9.5f} {8:9.5f}\n'\
-                             .format(di.i + 1, di.j + 1, di.k + 1, di.l + 1, 5,
-                             di.par[0], di.par[1], di.par[2], di.par[3]))
                 f.write('\n')
 
                 # 1-4 exclusion list should be built from bond instead of dihedral
@@ -1946,8 +1923,31 @@ class system(object):
                 f.write('[ pairs ]\n')
                 f.write(';   ai   aj   func\n')
                 for i, j in pairs14:
-                    f.write('{0:5d} {1:5d}     {2:2d}\n'\
-                             .format(i + 1, j + 1, 1))
+                    f.write('{0:5d} {1:5d}     {2:2d}\n' \
+                            .format(i + 1, j + 1, 1))
+                f.write('\n')
+
+                f.write('[ angles ]\n')
+                f.write(';  ai    aj    ak   func    th0        cth\n')
+                for an in sp.angle:
+                    f.write('{0:5d} {1:5d} {2:5d}     {3:2d}  '
+                            '{4:9.3f}  {5:9.3f}\n'\
+                             .format(an.i + 1, an.j + 1, an.k + 1, 1,
+                             an.par[0], an.par[1]))
+                f.write('\n')
+
+                f.write('[ dihedrals ]\n')
+                f.write(';  ai    aj    ak    al   func    coefficients\n')
+                for dh in sp.dihed:
+                    f.write('{0:5d} {1:5d} {2:5d} {3:5d}     {4:2d}  '
+                            '{5:9.5f} {6:9.5f} {7:9.5f} {8:9.5f}\n'\
+                             .format(dh.i + 1, dh.j + 1, dh.k + 1, dh.l + 1, 5,
+                             dh.par[0], dh.par[1], dh.par[2], dh.par[3]))
+                for di in sp.dimpr:
+                    f.write('{0:5d} {1:5d} {2:5d} {3:5d}     {4:2d}  '
+                            '{5:9.5f} {6:9.5f} {7:9.5f} {8:9.5f}\n'\
+                             .format(di.i + 1, di.j + 1, di.k + 1, di.l + 1, 5,
+                             di.par[0], di.par[1], di.par[2], di.par[3]))
                 f.write('\n')
 
             f.write('[ system ]\n')
@@ -1979,13 +1979,12 @@ class system(object):
             f.write("END\n")
 
         with open('run.mdp', 'w') as f:
-            f.write('integrator            = md\n')
+            f.write('integrator            = sd; md\n')
             f.write('dt                    = 0.001\n')
             f.write('nsteps                = 10000\n\n')
             
             f.write('nstlog                = 1000\n')
-            f.write('nstenergy             = 1000\n')
-            f.write('nstxout-compressed    = 100\n\n')
+            f.write('nstxout-compressed    = 1000\n\n')
 
             f.write('cutoff-scheme         = Verlet\n')
             f.write('pbc                   = xyz\n\n')
@@ -1993,25 +1992,21 @@ class system(object):
             f.write('coulombtype           = PME\n')
             f.write('rcoulomb              = 1.2\n')
             f.write('ewald-rtol            = 1.0e-5\n')
-            f.write('fourierspacing        = 0.06\n')
-            f.write('pme-order             = 8\n')
             f.write('vdwtype               = Cut-off\n')
             f.write('rvdw                  = 1.2\n')
             f.write('DispCorr              = EnerPres\n\n')
 
-            f.write('tcoupl                = V-rescale\n')
+            f.write('tcoupl                = no; V-rescale\n')
             f.write('tc-grps               = System\n')
             f.write('tau-t                 = 0.1\n')
             f.write('ref-t                 = 300.0\n\n')
 
-            f.write('pcoupl                = Berendsen\n')
-            f.write('; pcoupl                = Parrinello-Rahman\n')
+            f.write('pcoupl                = Berendsen; Parrinello-Rahman\n')
             f.write('pcoupltype            = isotropic\n')
-            f.write('tau-p                 = 1.0\n')
+            f.write('tau-p                 = 1.0; 5.0\n')
             f.write('ref-p                 = 1.0\n\n')
             f.write('compressibility       = 4.5e-5\n')
-            f.write('; refcoord_scaling      = com\n\n')
-            
+
             f.write('gen-vel               = yes\n')
             f.write('gen-temp              = 300\n')
             f.write('gen-seed              = -1\n\n')

--- a/fftool
+++ b/fftool
@@ -1787,7 +1787,7 @@ class system(object):
                 for im in range(sp.nmol):
                     for at in sp.atom:
                         f.write("{0:7d} {1:7d} {2:4d} {3:10.6f} "\
-                                 "{4:8.3f} {5:8.3f} {6:8.3f}  "\
+                                 "{4:13.6e} {5:13.6e} {6:13.6e}  "\
                                  "# {7} {8}\n".format(
                                  i + 1, nmol + 1, at.ityp + 1, at.q, 
                                  self.x[i], self.y[i], self.z[i],

--- a/fftool
+++ b/fftool
@@ -1878,7 +1878,7 @@ class system(object):
                 for at in sp.atom:
                     f.write('{0:5d}   {1:4s}  {2:5d}  {3:6s}   {4:5s}  {5:4d}'\
                             '  {6:10.6f}\n'.format(i, at.name, 1,
-                            sp.name[0:5], atomic_symbol(at.name), i, at.q))
+                            sp.name[:4], atomic_symbol(at.name)[:4], i, at.q))
                     i += 1
                 f.write('\n')
 
@@ -1968,10 +1968,10 @@ class system(object):
             for sp in self.spec:
                 for im in range(sp.nmol):
                     for at in sp.atom:
-                        f.write('HETATM{0:5d} {1:4s} {2:3s}  {3:4d}    '\
+                        f.write('HETATM{0:5d} {1:4s} {2:4s}  {3:4d}    '\
                                 '{4:8.3f}{5:8.3f}{6:8.3f}  1.00  0.00'\
-                                '          {7:2s}\n'.format(i + 1, atomic_symbol(at.name),
-                                sp.name[:3], nmol + 1,
+                                '          {7:2s}\n'.format(i + 1, atomic_symbol(at.name)[:4],
+                                sp.name[:4], nmol + 1,
                                 self.x[i], self.y[i], self.z[i],
                                 atomic_symbol(at.name)))
                         i += 1


### PR DESCRIPTION
1-4 exclusion should be built from bonds, instead of dihedrals. In some cases, dihedrals are ignored intentionally.
Minor fix for the format of top and pdb file.